### PR TITLE
feat: command registry schema, discord README, cross-platform build (102 tests)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -20,15 +20,15 @@
   - Added `workers/clanka-discord/commands/registry.test.ts` coverage for `validatePrUrl` valid/non-GitHub/missing-PR cases and command option parsing for `/review`, `/scan`, and unknown command errors.
 - [x] **Surface risk summary in `/review` response using existing `riskScore`** (2026-03-01)
   - `commandReview` now computes `riskScore(diffText)`, builds `riskSummary`, and returns it in the response payload with risk details in the Discord message.
-- [ ] **Introduce a runtime command schema for `workers/clanka-discord/commands/registry.ts`**
-  - Replace the inline `commandRegistry` map with a typed schema carrying name, description, handler, and option definitions so command registration and runtime dispatch share the same source of truth.
-- [ ] **Make worker build script cross-platform**
-  - Replace `workers/clanka-discord/package.json` `build` script’s macOS-only `sed -i ''` usage with a portable transformation step so Linux CI/dev environments can build reliably.
-- [ ] **Add documentation for production env wiring and required tokens/secrets**
-  - Create a docs page that explicitly lists `DISCORD_PUBLIC_KEY`, `DISCORD_APPLICATION_ID`, `CLANKA_ADMIN_IDS`, `GITHUB_TOKEN`, `SUPABASE_*`, and local/Cloudflare configuration expectations.
+- [x] **Introduce a runtime command schema for `workers/clanka-discord/commands/registry.ts`** (2026-03-01)
+  - Added typed runtime command schema entries with `name`, `description`, `handler`, and option definitions; runtime dispatch now resolves commands via schema lookup helpers.
+- [x] **Make worker build script cross-platform** (2026-03-01)
+  - Replaced macOS-specific shell script build flow with `workers/clanka-discord/scripts/build.mjs` and updated the package build script to use Node-based file copy/rewrite logic.
+- [x] **Add documentation for production env wiring and required tokens/secrets** (2026-03-01)
+  - Added `workers/clanka-discord/README.md` with required production secrets/vars, Cloudflare wiring, and local/deploy command flow.
 
 ## 🟢 Low Priority / Nice to Have
-- [ ] **`workers/clanka-discord` — add command registry** — current Discord handler likely handles one or few slash commands. Add a typed command registry so adding new commands is a one-liner.
+- [x] **`workers/clanka-discord` — add command registry** — typed runtime command schema and name-based lookup helpers added for dispatch/metadata reuse (2026-03-01).
 - [x] **`shared/spine.ts` — risk scoring** — `riskScore(diff)` added and exported, with tests covering lines changed, files touched, test ratio, src/config weighting, and 0–100 bounds (2026-02-28).
 - [ ] **`docs/` — add architecture diagram** — show how `shield.ts` and `spine.ts` are used by the Discord worker and any other consumers.
 - [ ] **Add `workers/clanka-discord` tests for command handlers**

--- a/workers/clanka-discord/README.md
+++ b/workers/clanka-discord/README.md
@@ -1,0 +1,65 @@
+# clanka-discord worker
+
+Discord interaction worker for Clanka slash commands.
+
+## Required production environment
+
+Set these in Cloudflare for the `clanka-discord` worker:
+
+1. `DISCORD_PUBLIC_KEY` (secret)  
+   Discord app public key used by `verifyKey()` to validate interaction signatures.
+2. `DISCORD_APPLICATION_ID` (secret or var)  
+   Discord application id used for slash command registration.
+3. `DISCORD_TOKEN` (secret)  
+   Discord bot token used by `scripts/register.js`.
+4. `CLANKA_ADMIN_IDS` (var)  
+   Comma-separated Discord user IDs allowed to run commands.
+5. `GITHUB_TOKEN` (secret)  
+   GitHub token used by `/review` when reading PR metadata and diffs.
+6. `SUPABASE_URL` (secret or var)  
+   Base project URL used by `/feedback`.
+7. `SUPABASE_SERVICE_ROLE_KEY` (secret)  
+   Service role key used by `/feedback` for Supabase REST access.
+
+`wrangler.toml` also requires a bound KV namespace for `CLANKA_STATE`.
+
+## Configure production secrets/vars
+
+From `workers/clanka-discord`:
+
+```bash
+npx wrangler secret put DISCORD_PUBLIC_KEY
+npx wrangler secret put DISCORD_APPLICATION_ID
+npx wrangler secret put DISCORD_TOKEN
+npx wrangler secret put GITHUB_TOKEN
+npx wrangler secret put SUPABASE_URL
+npx wrangler secret put SUPABASE_SERVICE_ROLE_KEY
+npx wrangler secret put CLANKA_ADMIN_IDS
+```
+
+If you prefer non-secret vars for non-sensitive values, set them in `wrangler.toml` under `[vars]` or with `npx wrangler deploy --var KEY:VALUE`.
+
+## Build, register, deploy
+
+```bash
+npm install
+npm run build
+npm run register
+npm run deploy
+```
+
+`npm run register` sends command definitions to Discord using `DISCORD_APPLICATION_ID` and `DISCORD_TOKEN`.
+
+## Local development
+
+Use `.dev.vars` (or your shell env) before `npx wrangler dev`:
+
+```bash
+DISCORD_PUBLIC_KEY=...
+DISCORD_APPLICATION_ID=...
+DISCORD_TOKEN=...
+CLANKA_ADMIN_IDS=1234567890,9999999999
+GITHUB_TOKEN=...
+SUPABASE_URL=https://<project>.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=...
+```

--- a/workers/clanka-discord/package.json
+++ b/workers/clanka-discord/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "deploy": "wrangler deploy",
     "register": "node scripts/register.js",
-    "build": "mkdir -p dist && cp -r src/* dist/ && cp ../../shared/*.ts dist/ && sed -i '' 's|../../shared/|./|g' dist/index.ts"
+    "build": "node scripts/build.mjs"
   },
   "keywords": [],
   "author": "",

--- a/workers/clanka-discord/scripts/build.mjs
+++ b/workers/clanka-discord/scripts/build.mjs
@@ -1,0 +1,33 @@
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const workerRoot = resolve(scriptDir, "..");
+const repoRoot = resolve(workerRoot, "..", "..");
+const distRoot = resolve(workerRoot, "dist");
+
+const rewriteFile = async (filePath, replacements) => {
+  let content = await readFile(filePath, "utf8");
+  for (const [from, to] of replacements) {
+    content = content.replaceAll(from, to);
+  }
+  await writeFile(filePath, content, "utf8");
+};
+
+await rm(distRoot, { recursive: true, force: true });
+await mkdir(resolve(distRoot, "commands"), { recursive: true });
+await mkdir(resolve(distRoot, "shared"), { recursive: true });
+
+await cp(resolve(workerRoot, "src", "index.ts"), resolve(distRoot, "index.ts"));
+await cp(resolve(workerRoot, "commands", "registry.ts"), resolve(distRoot, "commands", "registry.ts"));
+await cp(resolve(repoRoot, "shared", "shield.ts"), resolve(distRoot, "shared", "shield.ts"));
+await cp(resolve(repoRoot, "shared", "spine.ts"), resolve(distRoot, "shared", "spine.ts"));
+
+await rewriteFile(resolve(distRoot, "index.ts"), [["../commands/registry", "./commands/registry"]]);
+await rewriteFile(resolve(distRoot, "commands", "registry.ts"), [
+  ["../../../shared/spine", "../shared/spine"],
+  ["../../../shared/shield", "../shared/shield"],
+]);
+
+console.log("Built worker runtime files to dist/");

--- a/workers/clanka-discord/scripts/register.js
+++ b/workers/clanka-discord/scripts/register.js
@@ -29,6 +29,10 @@ const COMMANDS = [
         required: false,
       },
     ],
+  },
+  {
+    name: 'help',
+    description: 'Show available commands',
   }
 ];
 

--- a/workers/clanka-discord/src/index.ts
+++ b/workers/clanka-discord/src/index.ts
@@ -3,7 +3,7 @@ import {
   verifyKey,
 } from 'discord-interactions';
 import {
-  commandRegistry,
+  getCommandSchema,
   type CommandExecutionEnvironment,
   type DiscordInteraction,
   type DiscordResponse,
@@ -70,9 +70,9 @@ export default {
 
       if (interaction.type === InteractionType.APPLICATION_COMMAND) {
         const name = interaction.data?.name;
-        const handler = name ? commandRegistry[name] : undefined;
+        const command = getCommandSchema(name);
 
-        if (!handler) {
+        if (!command) {
           return new Response('Unknown command', { status: 400 });
         }
 
@@ -86,7 +86,7 @@ export default {
           env: commandEnv,
         };
 
-        return jsonResponse(await handler(commandInteraction));
+        return jsonResponse(await command.handler(commandInteraction));
       }
 
       return jsonResponse({


### PR DESCRIPTION
- Typed command registry in `workers/clanka-discord/commands/registry.ts`\n- `workers/clanka-discord/README.md`: production env wiring + required secrets\n- Cross-platform build script (`scripts/build.mjs`) replacing macOS-specific shell idioms\n- Integration tests: load, lookup, unknown command handling\n\n102 tests (up from 81)