### PR TITLE
feat: command handler tests, architecture doc (132 tests)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,5 @@
 # TASKS.md — clanka-tools
-> Last updated: 2026-02-28 | Status: open
+> Last updated: 2026-03-01 | Status: open
 
 ## 🔴 High Priority
 - [x] **Add tests for `shared/shield.ts`** — 27 tests written and passing (2026-02-26)
@@ -30,16 +30,17 @@
 ## 🟢 Low Priority / Nice to Have
 - [x] **`workers/clanka-discord` — add command registry** — typed runtime command schema and name-based lookup helpers added for dispatch/metadata reuse (2026-03-01).
 - [x] **`shared/spine.ts` — risk scoring** — `riskScore(diff)` added and exported, with tests covering lines changed, files touched, test ratio, src/config weighting, and 0–100 bounds (2026-02-28).
-- [ ] **`docs/` — add architecture diagram** — show how `shield.ts` and `spine.ts` are used by the Discord worker and any other consumers.
-- [ ] **Add `workers/clanka-discord` tests for command handlers**
-  - New `workers/clanka-discord/commands/registry.test.ts` covering `/status`, `/help`, and happy-path `/review`/`/feedback` response formatting with mocked fetch.
+- [x] **`docs/` — add architecture diagram** (2026-03-01)
+  - Added `docs/architecture.md` with ASCII diagrams showing `shield.ts` and `spine.ts` flow through the Discord worker and shared consumers.
+- [x] **Add `workers/clanka-discord` tests for command handlers** (2026-03-01)
+  - Added `workers/clanka-discord/commands/handlers.test.ts` covering `/status`, `/help`, `/review`, and `/feedback` with mocked Discord interaction objects and mocked fetch responses.
 - [ ] **Add explicit admin-id sanitization and diagnostics for `CLANKA_ADMIN_IDS`**
   - Trim/deduplicate IDs during parse and return a diagnostic deny message when the allowlist is empty or malformed instead of silently allowing broad access patterns.
 - [ ] **Add a lightweight docs/ADR for error handling policy**
   - Document how each command handles malformed input, upstream API failures, and timeout behavior so future contributors extend behavior consistently.
 
 ## 🧠 Notes
-- No root `package.json` — run commands inside `workers/clanka-discord/`
+- Root `package.json` exists and runs workspace build/test commands
 - `shared/shield.ts`: prompt injection / DoS guard — `triageInput(input): { safe, reason }`
 - `shared/spine.ts`: diff structure analysis — `analyzeDiff(diff): DiffInfo`
 - `workers/clanka-discord/`: Cloudflare Worker handling Discord interactions

--- a/workers/clanka-discord/commands/handlers.test.ts
+++ b/workers/clanka-discord/commands/handlers.test.ts
@@ -1,0 +1,542 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  commandRegistry,
+  type CommandExecutionEnvironment,
+  type DiscordInteraction,
+} from "./registry";
+
+const commandEnv: CommandExecutionEnvironment = {
+  GITHUB_TOKEN: "github-token",
+  SUPABASE_URL: "https://example.supabase.co",
+  SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+};
+
+const makeReviewInteraction = (prUrl?: unknown): DiscordInteraction => ({
+  data: {
+    name: "review",
+    options: prUrl === undefined ? [] : [{ name: "pr_url", value: prUrl as string }],
+  },
+  env: commandEnv,
+});
+
+const makeFeedbackInteraction = (
+  limit?: string | number | boolean
+): DiscordInteraction => ({
+  data: {
+    name: "feedback",
+    options: limit === undefined ? [] : [{ name: "limit", value: limit }],
+  },
+  env: commandEnv,
+});
+
+describe("commandRegistry handlers", () => {
+  it("registers all expected handlers", () => {
+    expect(Object.keys(commandRegistry).sort()).toEqual([
+      "feedback",
+      "help",
+      "review",
+      "status",
+    ]);
+  });
+
+  it("maps every registered command to a callable function", () => {
+    for (const handler of Object.values(commandRegistry)) {
+      expect(typeof handler).toBe("function");
+    }
+  });
+
+  it("returns an operational response for /status", async () => {
+    const response = await commandRegistry.status({ env: commandEnv });
+    expect(response.type).toBe(4);
+    expect(response.data?.content).toContain("CLANKA: Operational");
+  });
+
+  it("returns command usage help for /help", async () => {
+    const response = await commandRegistry.help({ env: commandEnv });
+    expect(response.type).toBe(4);
+    expect(response.data?.content).toContain("/status");
+    expect(response.data?.content).toContain("/review");
+    expect(response.data?.content).toContain("/feedback");
+    expect(response.data?.content).toContain("/help");
+  });
+});
+
+describe("commandRegistry.feedback", () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns service unavailable when Supabase fetch rejects", async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValueOnce(new Error("network down"));
+
+    const response = await commandRegistry.feedback(makeFeedbackInteraction());
+    expect(response.data?.content).toContain("Feedback service is temporarily unavailable");
+  });
+
+  it("returns service unavailable when Supabase response is not ok", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response("forbidden", { status: 403 })
+    );
+
+    const response = await commandRegistry.feedback(makeFeedbackInteraction());
+    expect(response.data?.content).toContain("Feedback service is temporarily unavailable");
+  });
+
+  it("returns service unavailable when Supabase payload is malformed JSON", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response("not-json", { status: 200 })
+    );
+
+    const response = await commandRegistry.feedback(makeFeedbackInteraction());
+    expect(response.data?.content).toContain("Feedback service is temporarily unavailable");
+  });
+
+  it("returns a no-feedback message when the payload is empty", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+
+    const response = await commandRegistry.feedback(makeFeedbackInteraction());
+    expect(response.data?.content).toContain("No recent user feedback found");
+  });
+
+  it("returns a no-feedback message when payload is not an array", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 })
+    );
+
+    const response = await commandRegistry.feedback(makeFeedbackInteraction());
+    expect(response.data?.content).toContain("No recent user feedback found");
+  });
+
+  it("formats multiple feedback entries", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([
+          {
+            category: "Bug",
+            message: "First issue",
+            status: "open",
+            page_path: "/home",
+          },
+          {
+            category: "UX",
+            message: "Second issue",
+            status: "triaged",
+            page_path: "/settings",
+          },
+        ]),
+        { status: 200 }
+      )
+    );
+
+    const response = await commandRegistry.feedback(makeFeedbackInteraction(2));
+    expect(response.data?.content).toContain("Latest User Feedback (Last 2)");
+    expect(response.data?.content).toContain("**[Bug]** First issue");
+    expect(response.data?.content).toContain("Status: open | Page: /home");
+    expect(response.data?.content).toContain("**[UX]** Second issue");
+  });
+
+  it("falls back to default label values when fields are missing", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify([{}]), { status: 200 })
+    );
+
+    const response = await commandRegistry.feedback(makeFeedbackInteraction());
+    expect(response.data?.content).toContain("**[Uncategorized]** No message content");
+    expect(response.data?.content).toContain("Status: unknown | Page: unknown");
+  });
+
+  it("truncates long feedback messages to 100 chars with ellipsis", async () => {
+    const message = "x".repeat(120);
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([{ category: "Bug", message, status: "open", page_path: "/home" }]),
+        { status: 200 }
+      )
+    );
+
+    const response = await commandRegistry.feedback(makeFeedbackInteraction());
+    const truncated = `${"x".repeat(100)}...`;
+    expect(response.data?.content).toContain(truncated);
+  });
+
+  it("uses the default limit of 5 when no limit option is provided", async () => {
+    const fetchSpy = vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+
+    await commandRegistry.feedback(makeFeedbackInteraction());
+
+    const [requestUrl] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(requestUrl).toContain("limit=5");
+  });
+
+  it("floors decimal limit values", async () => {
+    const fetchSpy = vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+
+    await commandRegistry.feedback(makeFeedbackInteraction(3.9));
+
+    const [requestUrl] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(requestUrl).toContain("limit=3");
+  });
+
+  it("falls back to limit=5 when limit is zero", async () => {
+    const fetchSpy = vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+
+    await commandRegistry.feedback(makeFeedbackInteraction(0));
+
+    const [requestUrl] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(requestUrl).toContain("limit=5");
+  });
+
+  it("falls back to limit=5 when limit is negative", async () => {
+    const fetchSpy = vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+
+    await commandRegistry.feedback(makeFeedbackInteraction(-8));
+
+    const [requestUrl] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(requestUrl).toContain("limit=5");
+  });
+
+  it("falls back to limit=5 when limit is NaN-like", async () => {
+    const fetchSpy = vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+
+    await commandRegistry.feedback(makeFeedbackInteraction("not-a-number"));
+
+    const [requestUrl] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(requestUrl).toContain("limit=5");
+  });
+
+  it("accepts boolean limit=true as numeric 1", async () => {
+    const fetchSpy = vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+
+    await commandRegistry.feedback(makeFeedbackInteraction(true));
+
+    const [requestUrl] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(requestUrl).toContain("limit=1");
+  });
+
+  it("sends Supabase auth headers on feedback requests", async () => {
+    const fetchSpy = vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+
+    await commandRegistry.feedback(makeFeedbackInteraction());
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.apikey).toBe(commandEnv.SUPABASE_SERVICE_ROLE_KEY);
+    expect(headers.Authorization).toBe(`Bearer ${commandEnv.SUPABASE_SERVICE_ROLE_KEY}`);
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+});
+
+describe("commandRegistry.review", () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns an argument error when pr_url is missing", async () => {
+    const response = await commandRegistry.review(makeReviewInteraction());
+    expect(response.data?.content).toContain("Missing or invalid `pr_url` argument.");
+  });
+
+  it("returns an argument error when pr_url is not a string", async () => {
+    const response = await commandRegistry.review(makeReviewInteraction(123));
+    expect(response.data?.content).toContain("Missing or invalid `pr_url` argument.");
+  });
+
+  it("returns a shield alert for blocked prompt-injection input", async () => {
+    const response = await commandRegistry.review(
+      makeReviewInteraction("javascript:alert(1)")
+    );
+
+    expect(response.data?.content).toContain("Shield Alert");
+  });
+
+  it("rejects invalid URL format", async () => {
+    const response = await commandRegistry.review(makeReviewInteraction("not-a-url"));
+    expect(response.data?.content).toContain("Invalid URL format.");
+  });
+
+  it("rejects non-GitHub pull request URLs", async () => {
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://gitlab.com/example/repo/-/merge_requests/1")
+    );
+
+    expect(response.data?.content).toContain("Only GitHub pull request URLs are supported.");
+  });
+
+  it("rejects GitHub URLs with missing PR number", async () => {
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/")
+    );
+
+    expect(response.data?.content).toContain("Missing pull request number in URL.");
+  });
+
+  it("rejects GitHub URLs with non-numeric PR number", async () => {
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/abc")
+    );
+
+    expect(response.data?.content).toContain("Invalid GitHub PR URL.");
+  });
+
+  it("returns service unavailable when GitHub requests reject", async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValueOnce(new Error("network down"));
+
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/9")
+    );
+
+    expect(response.data?.content).toContain("PR Review service is temporarily unavailable");
+  });
+
+  it("returns service unavailable when PR response is non-ok", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response("forbidden", { status: 403 }))
+      .mockResolvedValueOnce(new Response("diff text", { status: 200 }));
+
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/9")
+    );
+
+    expect(response.data?.content).toContain("PR Review service is temporarily unavailable");
+  });
+
+  it("returns service unavailable when PR JSON payload is malformed", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response("not-json", { status: 200 }))
+      .mockResolvedValueOnce(new Response("diff text", { status: 200 }));
+
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/9")
+    );
+
+    expect(response.data?.content).toContain("PR Review service is temporarily unavailable");
+  });
+
+  it("returns service unavailable when diff body cannot be read", async () => {
+    const diffResponse = {
+      ok: true,
+      text: vi.fn().mockRejectedValue(new Error("stream closed")),
+    } as unknown as Response;
+
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            user: { login: "octocat" },
+            title: "Refactor module",
+            additions: 2,
+            deletions: 1,
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(diffResponse);
+
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/9")
+    );
+
+    expect(response.data?.content).toContain("PR Review service is temporarily unavailable");
+  });
+
+  it("still returns a review when diff endpoint is non-ok", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            user: { login: "octocat" },
+            title: "Refactor module",
+            additions: 2,
+            deletions: 1,
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(new Response("not found", { status: 404 }));
+
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/9")
+    );
+
+    expect(response.data?.content).toContain("PR Review: #9 in example/repo");
+    expect(response.data?.content).toContain("**Risk:** LOW (0/100)");
+    expect(response.data?.riskSummary?.level).toBe("low");
+  });
+
+  it("formats a successful review payload with risk summary", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            user: { login: "octocat" },
+            title: "Improve parser behavior",
+            additions: 12,
+            deletions: 4,
+          }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          [
+            "diff --git a/src/app.ts b/src/app.ts",
+            "--- a/src/app.ts",
+            "+++ b/src/app.ts",
+            "@@ -1 +1 @@",
+            "-export const oldValue = 1;",
+            "+export const newValue = 2;",
+          ].join("\n"),
+          { status: 200 }
+        )
+      );
+
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/123")
+    );
+
+    expect(response.type).toBe(4);
+    expect(response.data?.content).toContain("PR Review: #123 in example/repo");
+    expect(response.data?.content).toContain("Title:** Improve parser behavior");
+    expect(response.data?.content).toContain("Author:** octocat");
+    expect(response.data?.content).toContain("Diff:** +12 / -4");
+    expect(response.data?.content).toContain("Risk:");
+    expect(response.data?.riskSummary).toBeDefined();
+  });
+
+  it("falls back to default title/author/diff counts when PR fields are missing", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+      .mockResolvedValueOnce(new Response("", { status: 200 }));
+
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/7")
+    );
+
+    expect(response.data?.content).toContain("Title:** Untitled");
+    expect(response.data?.content).toContain("Author:**");
+    expect(response.data?.content).toContain("Diff:** +0 / -0");
+  });
+
+  it("accepts GitHub URLs on the www subdomain", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+      .mockResolvedValueOnce(new Response("", { status: 200 }));
+
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://www.github.com/example/repo/pull/21")
+    );
+
+    expect(response.data?.content).toContain("PR Review: #21 in example/repo");
+  });
+
+  it("sends GitHub token and expected Accept headers in both review fetches", async () => {
+    const fetchSpy = vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+      .mockResolvedValueOnce(new Response("", { status: 200 }));
+
+    await commandRegistry.review(makeReviewInteraction("https://github.com/example/repo/pull/4"));
+
+    const [, firstInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const [, secondInit] = fetchSpy.mock.calls[1] as [string, RequestInit];
+    const firstHeaders = firstInit.headers as Record<string, string>;
+    const secondHeaders = secondInit.headers as Record<string, string>;
+
+    expect(firstHeaders.Authorization).toBe("Bearer github-token");
+    expect(firstHeaders.Accept).toBe("application/vnd.github.v3+json");
+    expect(secondHeaders.Authorization).toBe("Bearer github-token");
+    expect(secondHeaders.Accept).toBe("application/vnd.github.v3.diff");
+  });
+
+  it("handles PR payloads that parse to null by using safe defaults", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response("null", { status: 200 }))
+      .mockResolvedValueOnce(new Response("", { status: 200 }));
+
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/2")
+    );
+
+    expect(response.data?.content).toContain("Title:** Untitled");
+    expect(response.data?.content).toContain("Diff:** +0 / -0");
+  });
+
+  it("returns high risk summary for large src-only diffs", async () => {
+    const addedLines = Array.from({ length: 120 }, (_, index) => `+const x${index} = ${index};`);
+    const diffText = [
+      "diff --git a/src/risk.ts b/src/risk.ts",
+      "--- a/src/risk.ts",
+      "+++ b/src/risk.ts",
+      "@@ -0,0 +1,120 @@",
+      ...addedLines,
+    ].join("\n");
+
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+      .mockResolvedValueOnce(new Response(diffText, { status: 200 }));
+
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/88")
+    );
+
+    expect(response.data?.riskSummary?.level).toBe("high");
+    expect(response.data?.riskSummary?.score).toBeGreaterThanOrEqual(67);
+  });
+
+  it("returns low risk summary for tiny non-src diffs", async () => {
+    const diffText = [
+      "diff --git a/README.md b/README.md",
+      "--- a/README.md",
+      "+++ b/README.md",
+      "@@ -1 +1 @@",
+      "-old",
+      "+new",
+    ].join("\n");
+
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+      .mockResolvedValueOnce(new Response(diffText, { status: 200 }));
+
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/89")
+    );
+
+    expect(response.data?.riskSummary?.level).toBe("low");
+    expect(response.data?.riskSummary?.score).toBeLessThanOrEqual(33);
+  });
+
+  it("returns service unavailable when one of Promise.all fetches rejects", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+      .mockRejectedValueOnce(new Error("diff endpoint failed"));
+
+    const response = await commandRegistry.review(
+      makeReviewInteraction("https://github.com/example/repo/pull/99")
+    );
+
+    expect(response.data?.content).toContain("PR Review service is temporarily unavailable");
+  });
+});

--- a/workers/clanka-discord/scripts/register.test.ts
+++ b/workers/clanka-discord/scripts/register.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from "vitest";
+
+type RegisterModule = {
+  COMMANDS: Array<{ name: string }>;
+  parseCliArgs: (argv?: string[]) => { json: boolean; help: boolean };
+  registerCommands: (options?: {
+    applicationId?: string;
+    token?: string;
+    fetchImpl?: typeof fetch;
+    log?: (message: string) => void;
+    errorLog?: (message: string) => void;
+    argv?: string[];
+  }) => Promise<{ ok: boolean; error?: string; status?: number; data?: unknown }>;
+};
+
+const loadRegisterModule = async (): Promise<RegisterModule> => {
+  const mod = await import("./register.js");
+  return (mod.default ?? mod) as RegisterModule;
+};
+
+describe("workers/clanka-discord/scripts/register CLI", () => {
+  it("parses --json and --help flags", async () => {
+    const registerModule = await loadRegisterModule();
+
+    expect(registerModule.parseCliArgs(["--json"])).toEqual({
+      json: true,
+      help: false,
+    });
+    expect(registerModule.parseCliArgs(["--help"])).toEqual({
+      json: false,
+      help: true,
+    });
+    expect(registerModule.parseCliArgs(["-h"])).toEqual({
+      json: false,
+      help: true,
+    });
+  });
+
+  it("returns help output for --help in plain text mode", async () => {
+    const registerModule = await loadRegisterModule();
+    const log = vi.fn<(message: string) => void>();
+
+    const result = await registerModule.registerCommands({
+      argv: ["--help"],
+      log,
+      errorLog: vi.fn(),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(log).toHaveBeenCalledWith("Usage: node scripts/register.js [--json]");
+  });
+
+  it("returns help output for --help in json mode", async () => {
+    const registerModule = await loadRegisterModule();
+    const log = vi.fn<(message: string) => void>();
+
+    const result = await registerModule.registerCommands({
+      argv: ["--help", "--json"],
+      log,
+      errorLog: vi.fn(),
+    });
+
+    expect(result.ok).toBe(true);
+    const payload = JSON.parse(log.mock.calls[0][0]) as {
+      ok: boolean;
+      usage: string;
+      commands: string[];
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.usage).toBe("Usage: node scripts/register.js [--json]");
+    expect(payload.commands).toContain("review");
+  });
+
+  it("returns missing-env error in plain text mode", async () => {
+    const registerModule = await loadRegisterModule();
+    const errorLog = vi.fn<(message: string) => void>();
+
+    const result = await registerModule.registerCommands({
+      applicationId: "",
+      token: "",
+      argv: [],
+      log: vi.fn(),
+      errorLog,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Missing DISCORD_APPLICATION_ID or DISCORD_TOKEN");
+    expect(errorLog).toHaveBeenCalledWith("Missing DISCORD_APPLICATION_ID or DISCORD_TOKEN");
+  });
+
+  it("returns missing-env error in --json mode", async () => {
+    const registerModule = await loadRegisterModule();
+    const log = vi.fn<(message: string) => void>();
+
+    const result = await registerModule.registerCommands({
+      applicationId: "",
+      token: "",
+      argv: ["--json"],
+      log,
+      errorLog: vi.fn(),
+    });
+
+    expect(result.ok).toBe(false);
+    const payload = JSON.parse(log.mock.calls[0][0]) as { ok: boolean; error: string };
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toContain("Missing DISCORD_APPLICATION_ID or DISCORD_TOKEN");
+  });
+
+  it("logs success payload in plain text mode", async () => {
+    const registerModule = await loadRegisterModule();
+    const log = vi.fn<(message: string) => void>();
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify([{ id: "1", name: "status" }]), { status: 200 })
+    );
+
+    const result = await registerModule.registerCommands({
+      applicationId: "app-id",
+      token: "bot-token",
+      fetchImpl,
+      argv: [],
+      log,
+      errorLog: vi.fn(),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(log).toHaveBeenCalledWith("Successfully registered commands");
+    expect(log.mock.calls[1][0]).toContain("\"status\"");
+  });
+
+  it("logs success payload in --json mode", async () => {
+    const registerModule = await loadRegisterModule();
+    const log = vi.fn<(message: string) => void>();
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify([{ id: "2", name: "review" }]), { status: 200 })
+    );
+
+    const result = await registerModule.registerCommands({
+      applicationId: "app-id",
+      token: "bot-token",
+      fetchImpl,
+      argv: ["--json"],
+      log,
+      errorLog: vi.fn(),
+    });
+
+    expect(result.ok).toBe(true);
+    const payload = JSON.parse(log.mock.calls[0][0]) as {
+      ok: boolean;
+      commandCount: number;
+      data: Array<{ name: string }>;
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.commandCount).toBe(registerModule.COMMANDS.length);
+    expect(payload.data[0].name).toBe("review");
+  });
+
+  it("returns non-ok response details in --json mode", async () => {
+    const registerModule = await loadRegisterModule();
+    const log = vi.fn<(message: string) => void>();
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("discord error", { status: 400 })
+    );
+
+    const result = await registerModule.registerCommands({
+      applicationId: "app-id",
+      token: "bot-token",
+      fetchImpl,
+      argv: ["--json"],
+      log,
+      errorLog: vi.fn(),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    const payload = JSON.parse(log.mock.calls[0][0]) as {
+      ok: boolean;
+      status: number;
+      error: string;
+    };
+    expect(payload.ok).toBe(false);
+    expect(payload.status).toBe(400);
+    expect(payload.error).toContain("discord error");
+  });
+
+  it("returns network errors in plain text mode", async () => {
+    const registerModule = await loadRegisterModule();
+    const errorLog = vi.fn<(message: string) => void>();
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(
+      new Error("Network unreachable")
+    );
+
+    const result = await registerModule.registerCommands({
+      applicationId: "app-id",
+      token: "bot-token",
+      fetchImpl,
+      argv: [],
+      log: vi.fn(),
+      errorLog,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Network unreachable");
+    expect(errorLog).toHaveBeenCalledWith("Error registering commands");
+    expect(errorLog).toHaveBeenCalledWith("Network unreachable");
+  });
+});


### PR DESCRIPTION
- Handler tests for Discord slash commands with mocked interaction objects\n- `docs/architecture.md` with ASCII diagram of shield.ts/spine.ts usage\n\n132 tests (up from 102)