### PR TITLE
chore: add pre-push hook to run tests before push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "pre-push: running test suite..."
+if ! npm test; then
+  echo "pre-push: tests failed. Aborting push."
+  exit 1
+fi
+
+echo "pre-push: checks passed."
+exit 0

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "build": "cd workers/clanka-discord && npm run build"
+    "build": "cd workers/clanka-discord && npm run build",
+    "prepare": "git config core.hooksPath .githooks"
   },
   "devDependencies": {
     "vitest": "^4.0.18",


### PR DESCRIPTION
## Summary
- add .githooks/pre-push to run npm test and block pushes on failures
- add a root prepare script to set core.hooksPath to .githooks
- verify the hook locally before push

## Verification
- npm run prepare
- sh .githooks/pre-push
- git push -u origin chore/pre-push-hook