### PR TITLE
fix(docs): correct root README operator instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,33 @@
 # clanka-tools
 
-`clanka-tools` is a utility repo for shared guardrail logic and worker-level integrations around the Clanka automation surface. It currently includes a Discord-facing Worker package plus reusable parsing/triage modules used to keep inbound inputs and diff analysis deterministic.
+`clanka-tools` is a utility repo for shared guardrail logic and worker-level integrations around the Clanka automation surface. It currently includes Discord- and review-facing Worker packages plus reusable parsing/triage modules used to keep inbound inputs and diff analysis deterministic.
 
 ## Stack
 - TypeScript
-- Cloudflare Workers (`workers/clanka-discord`)
+- Cloudflare Workers (`workers/clanka-discord`, `workers/clanka-reviewer`)
 - Discord interactions (`discord-interactions`)
+- Vitest (root workspace test runner)
 
 ## Repo Layout
 - `shared/shield.ts` - prompt/input triage (`triageInput`, `SHIELD_PATTERNS`)
-- `shared/spine.ts` - diff structure analysis (`analyzeDiff`)
-- `workers/clanka-discord/` - worker package + wrangler config + deploy scripts
-- `docs/` - runbook and codex notes
+- `shared/spine.ts` - diff structure analysis (`analyzeDiff`, `riskScore`)
+- `shared/healthz.ts` - shared health-check protocol (`createHealthCheck`)
+- `workers/clanka-discord/` - Discord interactions worker + wrangler config + deploy scripts
+- `workers/clanka-reviewer/` - heuristic review HTTP worker
+- `scripts/` - operator utilities (`dep-graph`, `ai-backlog-worker`)
+- `docs/` - runbook, architecture notes, and ADRs
 - `docs/adr/error-handling-policy.md` - command error-handling policy (malformed input, upstream failures, timeout policy)
 
 ## Run And Deploy
-This repo does not have a root `package.json`; run commands inside the worker package.
+Root `package.json` owns shared tests and convenience scripts. Worker install/build still runs inside the worker package when needed.
 
+```bash
+npm install
+npm test
+npm run dep-graph
+```
+
+Discord worker local loop:
 ```bash
 cd workers/clanka-discord
 npm install
@@ -24,7 +35,7 @@ npm run build
 npx wrangler dev
 ```
 
-Deploy worker:
+Deploy Discord worker:
 ```bash
 cd workers/clanka-discord
 npm run deploy
@@ -38,4 +49,5 @@ npm run register
 
 ## Key Exports
 - `triageInput(input: string)` from `shared/shield.ts`
-- `analyzeDiff(diffText: string)` from `shared/spine.ts`
+- `analyzeDiff(diffText: string)` / `riskScore(diffText: string)` from `shared/spine.ts`
+- `createHealthCheck(opts)` from `shared/healthz.ts`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Root `README.md` told operators the repo had no root `package.json` and skipped several surfaces that already exist (`healthz`, `clanka-reviewer`, `scripts/`).

## Changes
- Document root `npm install` / `npm test` / `npm run dep-graph`
- List shared healthz + reviewer worker + scripts honestly
- Keep Discord worker build/register/deploy steps accurate

## Test plan
- [x] README claims match repo layout (`package.json`, `shared/healthz.ts`, `workers/clanka-reviewer`, `scripts/`)
- [x] `npm test` green on push hook (173 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13797e52-eef1-4600-8607-e4153a5b6da6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13797e52-eef1-4600-8607-e4153a5b6da6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

