### PR TITLE
fix(discord): honest status and unavailable empty states

### DIFF
--- a/workers/clanka-discord/commands/handlers.test.ts
+++ b/workers/clanka-discord/commands/handlers.test.ts
@@ -51,10 +51,11 @@ describe("commandRegistry handlers", () => {
     }
   });
 
-  it("returns an operational response for /status", async () => {
+  it("returns an honest liveness response for /status", async () => {
     const response = await commandRegistry.status({ env: commandEnv });
     expect(response.type).toBe(4);
-    expect(response.data?.content).toContain("CLANKA: Operational");
+    expect(response.data?.content).toContain("Discord worker is responding");
+    expect(response.data?.content).toContain("does **not** verify");
   });
 
   it("returns command usage help for /help", async () => {
@@ -110,13 +111,14 @@ describe("commandRegistry.feedback", () => {
     expect(response.data?.content).toContain("No recent user feedback found");
   });
 
-  it("returns a no-feedback message when payload is not an array", async () => {
+  it("returns an unexpected-shape message when payload is not an array", async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(
       new Response(JSON.stringify({}), { status: 200 })
     );
 
     const response = await commandRegistry.feedback(makeFeedbackInteraction());
-    expect(response.data?.content).toContain("No recent user feedback found");
+    expect(response.data?.content).toContain("Unexpected response shape");
+    expect(response.data?.content).not.toContain("No recent user feedback found");
   });
 
   it("formats multiple feedback entries", async () => {
@@ -369,7 +371,7 @@ describe("commandRegistry.review", () => {
     expect(response.data?.content).toContain("PR Review service is temporarily unavailable");
   });
 
-  it("still returns a review when diff endpoint is non-ok", async () => {
+  it("does not present a missing diff as low risk", async () => {
     vi.mocked(globalThis.fetch)
       .mockResolvedValueOnce(
         new Response(
@@ -389,8 +391,10 @@ describe("commandRegistry.review", () => {
     );
 
     expect(response.data?.content).toContain("PR Review: #9 in example/repo");
-    expect(response.data?.content).toContain("**Risk:** LOW (0/100)");
-    expect(response.data?.riskSummary?.level).toBe("low");
+    expect(response.data?.content).toContain("Diff unavailable");
+    expect(response.data?.content).toContain("HTTP 404");
+    expect(response.data?.content).not.toContain("**Risk:** LOW");
+    expect(response.data?.riskSummary).toBeUndefined();
   });
 
   it("formats a successful review payload with risk summary", async () => {

--- a/workers/clanka-discord/commands/registry.test.ts
+++ b/workers/clanka-discord/commands/registry.test.ts
@@ -153,7 +153,7 @@ describe("runtime command registry integration", () => {
   it("looks up /status by command name", () => {
     const command = getCommandSchema("status");
     expect(command?.name).toBe("status");
-    expect(command?.description).toContain("status");
+    expect(command?.description).toContain("responding");
   });
 
   it("looks up /review metadata including option schema", () => {
@@ -226,11 +226,12 @@ describe("runtime command handlers", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns operational message for /status", async () => {
+  it("returns honest liveness message for /status", async () => {
     const statusHandler = requireHandler("status");
     const response = await statusHandler({ env: commandEnv });
     expect(response.type).toBe(4);
-    expect(response.data?.content).toContain("CLANKA: Operational");
+    expect(response.data?.content).toContain("Discord worker is responding");
+    expect(response.data?.content).toContain("does **not** verify");
   });
 
   it("returns command list for /help", async () => {

--- a/workers/clanka-discord/commands/registry.ts
+++ b/workers/clanka-discord/commands/registry.ts
@@ -234,7 +234,10 @@ const findOption = (
 };
 
 const commandStatus: DiscordCommandHandler = async () => {
-  return response('⚡ **CLANKA: Operational.** Systems verified. Shield active.');
+  return response(
+    '⚡ **CLANKA:** Discord worker is responding.\n' +
+      'This check does **not** verify GitHub, Supabase, or Shield health. Use `GET /healthz` for worker liveness metadata.'
+  );
 };
 
 const commandReview: DiscordCommandHandler = async (interaction) => {
@@ -308,21 +311,30 @@ const commandReview: DiscordCommandHandler = async (interaction) => {
       return serviceUnavailable('PR Review');
     }
 
-    let diffText = '';
-    if (diffRes.ok) {
-      try {
-        diffText = await diffRes.text();
-      } catch {
-        return serviceUnavailable('PR Review');
-      }
-    }
-    const analysis = analyzeDiff(diffText);
-
     const user = asObject(prData.user) ?? {};
     const author = asString(user.login);
     const title = asString(prData.title, 'Untitled');
     const additions = Number(prData.additions) || 0;
     const deletions = Number(prData.deletions) || 0;
+
+    if (!diffRes.ok) {
+      return response(
+        `🔍 **PR Review: #${pull_number} in ${owner}/${repo}**\n` +
+          `**Title:** ${title}\n` +
+          `**Author:** ${author}\n` +
+          `**Diff:** +${additions} / -${deletions}\n` +
+          `⚠️ **Diff unavailable** (GitHub returned HTTP ${diffRes.status}). Risk was not scored from missing diff content.`
+      );
+    }
+
+    let diffText = '';
+    try {
+      diffText = await diffRes.text();
+    } catch {
+      return serviceUnavailable('PR Review');
+    }
+
+    const analysis = analyzeDiff(diffText);
     const score = riskScore(diffText);
     const riskSummary = buildRiskSummary(score);
 
@@ -381,7 +393,12 @@ const commandFeedback: DiscordCommandHandler = async (interaction) => {
     let feedbackData: Array<Record<string, unknown>>;
     try {
       const payload = (await responsePayload.json()) as unknown;
-      feedbackData = Array.isArray(payload) ? (payload as Array<Record<string, unknown>>) : [];
+      if (!Array.isArray(payload)) {
+        return response(
+          '⚠️ **Feedback Engine:** Unexpected response shape from Supabase (expected a list).'
+        );
+      }
+      feedbackData = payload as Array<Record<string, unknown>>;
     } catch {
       return serviceUnavailable('Feedback');
     }
@@ -415,7 +432,7 @@ const commandFeedback: DiscordCommandHandler = async (interaction) => {
 const commandHelp: DiscordCommandHandler = async () => {
   return response(
     `📘 **Clanka Commands**\n\n` +
-      `• \`/status\` - Check if Clanka is operational\n` +
+      `• \`/status\` - Confirm the Discord worker is responding (not a full dependency check)\n` +
       `• \`/review pr_url\` - Run a heuristic code review on a GitHub PR\n` +
       `• \`/feedback [limit]\` - Show recent user feedback from Supabase\n` +
       `• \`/help\` - Show this help message`
@@ -425,7 +442,7 @@ const commandHelp: DiscordCommandHandler = async () => {
 const runtimeCommandRegistry = [
   {
     name: 'status',
-    description: 'Check Clanka system status',
+    description: 'Confirm the Discord worker is responding',
     handler: commandStatus,
   },
   {

--- a/workers/clanka-discord/scripts/register.js
+++ b/workers/clanka-discord/scripts/register.js
@@ -1,7 +1,7 @@
 const COMMANDS = [
   {
     name: 'status',
-    description: 'Check Clanka system status',
+    description: 'Confirm the Discord worker is responding',
   },
   {
     name: 'review',

--- a/workers/clanka-discord/src/index.test.ts
+++ b/workers/clanka-discord/src/index.test.ts
@@ -254,7 +254,7 @@ describe("workers/clanka-discord index request handling", () => {
     const payload = (await response.json()) as { data: { content: string } };
 
     expect(response.status).toBe(200);
-    expect(payload.data.content).toContain("CLANKA: Operational");
+    expect(payload.data.content).toContain("Discord worker is responding");
   });
 
   it("denies access with diagnostics when admin allowlist is empty", async () => {
@@ -313,7 +313,7 @@ describe("workers/clanka-discord index request handling", () => {
     const payload = (await response.json()) as { data: { content: string } };
 
     expect(response.status).toBe(200);
-    expect(payload.data.content).toContain("CLANKA: Operational");
+    expect(payload.data.content).toContain("Discord worker is responding");
   });
 
   it("dispatches /help for authorized users", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Several Discord responses looked healthier than reality: `/status` claimed systems were verified, a failed PR diff fetch still scored **LOW (0/100)**, and a non-list Supabase payload was shown as “no feedback found.”

## Changes
- `/status` and help copy now describe worker reachability only (point to `GET /healthz`)
- Missing PR diffs report **Diff unavailable** instead of fabricating a low-risk score
- Non-array feedback payloads return an unexpected-shape warning
- Keep Discord slash-command registration description aligned

## Test plan
- [x] Updated handler/registry/index tests for status, missing-diff, and malformed feedback
- [x] `npm test` green (173)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13797e52-eef1-4600-8607-e4153a5b6da6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13797e52-eef1-4600-8607-e4153a5b6da6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

