### PR TITLE
fix(scripts): report when dep-graph SVG render is skipped

### DIFF
--- a/scripts/dep-graph.mjs
+++ b/scripts/dep-graph.mjs
@@ -132,9 +132,31 @@ export async function writeDependencyGraph(options = {}) {
   return { dotPath, svgPath, graph };
 }
 
+/**
+ * @param {{ rootDir: string, dotPath: string, svgPath: string | null }} result
+ * @returns {string[]}
+ */
+export function formatDepGraphWriteMessages(result) {
+  const messages = [`Wrote ${path.relative(result.rootDir, result.dotPath)}`];
+  if (result.svgPath) {
+    messages.push(`Wrote ${path.relative(result.rootDir, result.svgPath)}`);
+  } else {
+    messages.push(
+      "Skipped docs/dep-graph.svg: Graphviz `dot` not found on PATH. Install Graphviz to render SVG.",
+    );
+  }
+  return messages;
+}
+
 async function main() {
-  const { dotPath } = await writeDependencyGraph();
-  console.log(`Wrote ${path.relative(defaultRootDir, dotPath)}`);
+  const { dotPath, svgPath } = await writeDependencyGraph();
+  for (const message of formatDepGraphWriteMessages({
+    rootDir: defaultRootDir,
+    dotPath,
+    svgPath,
+  })) {
+    console.log(message);
+  }
 }
 
 /**

--- a/shared/dep-graph.test.ts
+++ b/shared/dep-graph.test.ts
@@ -1,5 +1,9 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { buildDependencyGraph } from "../scripts/dep-graph.mjs";
+import {
+  buildDependencyGraph,
+  formatDepGraphWriteMessages,
+} from "../scripts/dep-graph.mjs";
 
 describe("buildDependencyGraph", () => {
   it("returns a non-empty list of nodes for the repository graph", async () => {
@@ -7,5 +11,31 @@ describe("buildDependencyGraph", () => {
 
     expect(graph.nodes.length).toBeGreaterThan(0);
     expect(graph.nodes.some((node) => node.group === "shared")).toBe(true);
+  });
+});
+
+describe("formatDepGraphWriteMessages", () => {
+  const rootDir = "/repo";
+
+  it("reports both outputs when SVG rendering succeeded", () => {
+    expect(
+      formatDepGraphWriteMessages({
+        rootDir,
+        dotPath: path.join(rootDir, "docs/dep-graph.dot"),
+        svgPath: path.join(rootDir, "docs/dep-graph.svg"),
+      }),
+    ).toEqual(["Wrote docs/dep-graph.dot", "Wrote docs/dep-graph.svg"]);
+  });
+
+  it("reports an explicit skip when Graphviz is unavailable", () => {
+    const messages = formatDepGraphWriteMessages({
+      rootDir,
+      dotPath: path.join(rootDir, "docs/dep-graph.dot"),
+      svgPath: null,
+    });
+
+    expect(messages[0]).toBe("Wrote docs/dep-graph.dot");
+    expect(messages[1]).toContain("Skipped docs/dep-graph.svg");
+    expect(messages[1]).toContain("Graphviz");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`npm run dep-graph` only logged a successful DOT write even when Graphviz `dot` was missing, so operators could miss that `docs/dep-graph.svg` was never produced.

## Changes
- Print an explicit skip message when SVG rendering is unavailable
- Confirm SVG path when rendering succeeds
- Cover CLI message formatting in tests

## Test plan
- [x] Unit coverage for success + skipped Graphviz messaging
- [x] `npm test` green (175)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13797e52-eef1-4600-8607-e4153a5b6da6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13797e52-eef1-4600-8607-e4153a5b6da6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

