### PR TITLE
fix(discord): stop echoing Discord user IDs on access denial

### DIFF
--- a/workers/clanka-discord/src/index.test.ts
+++ b/workers/clanka-discord/src/index.test.ts
@@ -217,7 +217,9 @@ describe("workers/clanka-discord index request handling", () => {
     const payload = (await response.json()) as { data: { content: string } };
 
     expect(response.status).toBe(200);
-    expect(payload.data.content).toContain("Unauthorized User ID: unauthorized-user");
+    expect(payload.data.content).toContain("Access Denied.");
+    expect(payload.data.content).toContain("not on the admin allowlist");
+    expect(payload.data.content).not.toContain("unauthorized-user");
   });
 
   it("returns 400 for unknown command dispatch", async () => {

--- a/workers/clanka-discord/src/index.ts
+++ b/workers/clanka-discord/src/index.ts
@@ -115,7 +115,10 @@ export default {
       if (!allowedIds.includes(userId)) {
         return jsonResponse({
           type: 4,
-          data: { content: `🚫 **Access Denied.** Unauthorized User ID: ${userId}` },
+          data: {
+            content:
+              '🚫 **Access Denied.** Your Discord user is not on the admin allowlist.',
+          },
         });
       }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Unauthorized Discord interactions previously echoed the caller’s user ID into the channel response.

## Changes
- Keep access-denied messaging clear without reflecting identifiers
- Update worker coverage to assert the ID is not returned

## Test plan
- [x] Unauthorized-user test asserts allowlist message and no echoed ID
- [x] `npm test` green (173)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13797e52-eef1-4600-8607-e4153a5b6da6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13797e52-eef1-4600-8607-e4153a5b6da6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

